### PR TITLE
fix(i18n): replace top-level await in entry.client to fix cd-web build

### DIFF
--- a/web/app/entry.client.tsx
+++ b/web/app/entry.client.tsx
@@ -8,26 +8,29 @@ import jaCommon from "../public/locales/ja/common.json"
 import { defaultNS, fallbackLng, supportedLngs } from "./i18n"
 
 // Initialize with the SSR locale so hydration matches the server-rendered HTML.
-await i18next.use(initReactI18next).init({
-  lng: document.documentElement.lang || fallbackLng,
-  fallbackLng,
-  supportedLngs: [...supportedLngs],
-  defaultNS,
-  resources: { ja: { common: jaCommon }, en: { common: enCommon } },
-  interpolation: { escapeValue: false },
-})
+i18next
+  .use(initReactI18next)
+  .init({
+    lng: document.documentElement.lang || fallbackLng,
+    fallbackLng,
+    supportedLngs: [...supportedLngs],
+    defaultNS,
+    resources: { ja: { common: jaCommon }, en: { common: enCommon } },
+    interpolation: { escapeValue: false },
+  })
+  .then(() => {
+    startTransition(() => {
+      hydrateRoot(
+        document,
+        <StrictMode>
+          <HydratedRouter />
+        </StrictMode>,
+      )
+    })
 
-startTransition(() => {
-  hydrateRoot(
-    document,
-    <StrictMode>
-      <HydratedRouter />
-    </StrictMode>,
-  )
-})
-
-// After hydration, apply any localStorage preference that differs from the SSR locale.
-const savedLang = localStorage.getItem("ui_lang")
-if (savedLang && savedLang !== i18next.language) {
-  i18next.changeLanguage(savedLang)
-}
+    // After hydration, apply any localStorage preference that differs from the SSR locale.
+    const savedLang = localStorage.getItem("ui_lang")
+    if (savedLang && savedLang !== i18next.language) {
+      i18next.changeLanguage(savedLang)
+    }
+  })


### PR DESCRIPTION
## Summary
- Removes top-level `await` from `entry.client.tsx` which caused a build failure with esbuild target ES2020/Chrome87
- Replaces it with a `.then()` chain on `i18next.init()` — same initialization order, fully compatible output
- Fixes the `cd-web` GitHub Actions deployment failure

## Test plan
- [ ] `pnpm build` completes without errors
- [ ] UI language switching still works on the deployed site

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application initialization sequence to ensure language settings load correctly before the app renders, enhancing startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->