### PR TITLE
fix(deploy): point wrangler main to build/server/index.js

### DIFF
--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,5 +1,5 @@
 name = "gdgoc-wiki"
-main = "workers/app.ts"
+main = "build/server/index.js"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
After react-router build, virtual:react-router/server-build is already resolved into build/server/index.js. Wrangler must deploy that pre-built artifact — not re-bundle workers/app.ts — to avoid the unresolvable virtual module error.

## Summary

<!-- Describe what this PR does and why. -->

## Changes

-

## Test Plan

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if UI-facing)
- [ ] Manual testing completed

## Checklist

- [ ] `npm run check` passes (Biome lint + format)
- [ ] `npm run typecheck` passes
- [ ] `npm run test` passes
- [ ] Terraform: `terraform fmt` and `terraform validate` pass (if infra changed)
- [ ] No secrets or sensitive data committed
- [ ] Documentation / specs updated if needed

## Related Issues

<!-- Closes #123 -->
