### PR TITLE
fix(deploy): add custom route for wiki.gdgoc-osaka.jp

### DIFF
--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -13,6 +13,10 @@ compatibility_flags = ["nodejs_compat"]
 directory = "./build/client"
 binding = "ASSETS"
 
+[[routes]]
+pattern = "wiki.gdgoc-osaka.jp/*"
+zone_name = "gdgoc-osaka.jp"
+
 [vars]
 ENVIRONMENT = "development"
 


### PR DESCRIPTION
## Summary
- Adds `[[routes]]` entry to `wrangler.toml` so Wrangler knows where to deploy in CI
- Fixes the `cd-web` failure: _"You need to register a workers.dev subdomain"_ error in non-interactive mode
- Targets `wiki.gdgoc-osaka.jp/*` with `zone_name = "gdgoc-osaka.jp"`

## Test plan
- [ ] Verify `gdgoc-osaka.jp` is an active zone in the Cloudflare account
- [ ] Confirm `cd-web` GitHub Actions job completes successfully on merge to main

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added routing configuration support for the wiki subdomain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->