### PR TITLE
feat(ui): responsive design — full app

### DIFF
--- a/web/app/components/Navbar.tsx
+++ b/web/app/components/Navbar.tsx
@@ -161,7 +161,7 @@ export default function Navbar({
   }, [currentQuery])
 
   return (
-    <header className="fixed top-0 right-0 left-0 z-50 flex h-14 items-center gap-4 border-b border-gray-200 bg-white px-4">
+    <header className="fixed top-0 right-0 left-0 z-50 flex h-14 items-center gap-2 border-b border-gray-200 bg-white px-3 sm:gap-4 sm:px-4">
       {/* Sidebar toggle */}
       {onToggleSidebar && (
         <button
@@ -177,7 +177,8 @@ export default function Navbar({
 
       {/* Logo */}
       <Link to="/" className="flex-shrink-0">
-        <img src="/logo.png" alt="GDGoC Japan Wiki" className="h-8 w-auto" />
+        <img src="/logo.png" alt="GDGoC Japan Wiki" className="hidden h-8 w-auto sm:block" />
+        <img src="/logo_square.png" alt="GDGoC Japan Wiki" className="h-8 w-auto sm:hidden" />
       </Link>
 
       {/* Search */}
@@ -197,7 +198,7 @@ export default function Navbar({
         {user && (
           <Link
             to="/ingest"
-            className="whitespace-nowrap rounded-md bg-blue-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-600"
+            className="hidden whitespace-nowrap rounded-md bg-blue-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-600 sm:flex"
           >
             + {t("nav.new_page")}
           </Link>

--- a/web/app/components/NotificationBell.tsx
+++ b/web/app/components/NotificationBell.tsx
@@ -146,7 +146,7 @@ export default function NotificationBell({ initialCount }: { initialCount: numbe
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-md border border-gray-200 bg-white shadow-lg">
+        <div className="absolute right-0 top-full z-50 mt-1 w-[calc(100vw-1.5rem)] max-w-72 rounded-md border border-gray-200 bg-white shadow-lg sm:w-72">
           <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2">
             <p className="text-sm font-semibold text-gray-900">{t("notifications.title")}</p>
             {unreadCount > 0 && (

--- a/web/app/components/PageEditor.tsx
+++ b/web/app/components/PageEditor.tsx
@@ -129,86 +129,92 @@ export default function PageEditor({ page, canPublish }: PageEditorProps) {
       {/* ------------------------------------------------------------------ */}
       {/* Mini-header                                                          */}
       {/* ------------------------------------------------------------------ */}
-      <div className="sticky top-14 z-10 flex items-center gap-3 border-b border-gray-200 bg-white px-4 py-2 shadow-sm">
-        {/* Back button */}
-        <Link
-          to={`/wiki/${page.slug}`}
-          className="shrink-0 rounded-md p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-          aria-label={t("editor.back_to_page")}
-        >
-          <ArrowLeft size={18} />
-        </Link>
-
-        {/* Title inputs — toggled by active language, both always in DOM */}
-        <input
-          name="titleJa"
-          value={titleJa}
-          onChange={(e) => setTitleJa(e.target.value)}
-          placeholder={t("editor.title_ja")}
-          required
-          className={`min-w-0 flex-1 rounded bg-transparent px-2 py-1 text-base font-medium text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 ${activeLang !== "ja" ? "hidden" : ""}`}
-        />
-        <input
-          name="titleEn"
-          value={titleEn}
-          onChange={(e) => setTitleEn(e.target.value)}
-          placeholder={t("editor.title_en")}
-          className={`min-w-0 flex-1 rounded bg-transparent px-2 py-1 text-base font-medium text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 ${activeLang !== "en" ? "hidden" : ""}`}
-        />
-
-        {/* Autosave status */}
-        {statusText && (
-          <span
-            className={`shrink-0 text-xs ${fetcher.data && !fetcher.data.ok ? "text-red-500" : "text-gray-400"}`}
+      <div className="sticky top-14 z-10 grid grid-cols-2 items-center gap-x-2 gap-y-1 border-b border-gray-200 bg-white px-3 py-2 shadow-sm sm:flex sm:flex-wrap sm:gap-2">
+        {/* Row 1 col 1 (mobile) / inline (desktop): back + title */}
+        <div className="flex min-w-0 items-center gap-1">
+          <Link
+            to={`/wiki/${page.slug}`}
+            className="shrink-0 rounded-md p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            aria-label={t("editor.back_to_page")}
           >
-            {statusText}
-          </span>
-        )}
+            <ArrowLeft size={18} />
+          </Link>
 
-        {/* Draft badge */}
-        {page.status === "draft" && (
-          <span className="shrink-0 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
-            Draft
-          </span>
-        )}
-
-        {/* Language switcher */}
-        <div className="flex shrink-0 overflow-hidden rounded-md border border-gray-200">
-          {(["ja", "en"] as const).map((lang) => (
-            <button
-              key={lang}
-              type="button"
-              onClick={() => setActiveLang(lang)}
-              className={`px-3 py-1 text-sm font-medium transition-colors ${
-                activeLang === lang
-                  ? "bg-gray-900 text-white"
-                  : "bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700"
-              }`}
-            >
-              {lang === "ja" ? t("language.ja") : t("language.en")}
-            </button>
-          ))}
+          {/* Title inputs — toggled by active language, both always in DOM */}
+          <input
+            name="titleJa"
+            value={titleJa}
+            onChange={(e) => setTitleJa(e.target.value)}
+            placeholder={t("editor.title_ja")}
+            required
+            className={`min-w-0 flex-1 rounded bg-transparent px-2 py-1 text-base font-medium text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 ${activeLang !== "ja" ? "hidden" : ""}`}
+          />
+          <input
+            name="titleEn"
+            value={titleEn}
+            onChange={(e) => setTitleEn(e.target.value)}
+            placeholder={t("editor.title_en")}
+            className={`min-w-0 flex-1 rounded bg-transparent px-2 py-1 text-base font-medium text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 ${activeLang !== "en" ? "hidden" : ""}`}
+          />
         </div>
 
-        {/* Action buttons */}
-        <button
-          type="submit"
-          name="intent"
-          value="save"
-          className="shrink-0 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          {t("editor.save_draft")}
-        </button>
-        {canPublish && (
+        {/* Row 1 col 2 (mobile) / inline (desktop): lang switcher + actions */}
+        <div className="flex shrink-0 items-center justify-end gap-2">
+          {/* Autosave status */}
+          {statusText && (
+            <span
+              className={`hidden shrink-0 text-xs sm:inline ${fetcher.data && !fetcher.data.ok ? "text-red-500" : "text-gray-400"}`}
+            >
+              {statusText}
+            </span>
+          )}
+
+          {/* Draft badge */}
+          {page.status === "draft" && (
+            <span className="hidden shrink-0 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 sm:inline">
+              Draft
+            </span>
+          )}
+
+          {/* Language switcher */}
+          <div className="flex shrink-0 overflow-hidden rounded-md border border-gray-200">
+            {(["ja", "en"] as const).map((lang) => (
+              <button
+                key={lang}
+                type="button"
+                onClick={() => setActiveLang(lang)}
+                className={`px-3 py-1 text-sm font-medium transition-colors ${
+                  activeLang === lang
+                    ? "bg-gray-900 text-white"
+                    : "bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700"
+                }`}
+              >
+                {lang === "ja" ? t("language.ja") : t("language.en")}
+              </button>
+            ))}
+          </div>
+
+          {/* Action buttons */}
           <button
             type="submit"
             name="intent"
-            value="publish"
-            className="shrink-0 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value="save"
+            className="shrink-0 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            {t("editor.publish")} ↗
+            <span className="hidden sm:inline">{t("editor.save_draft")}</span>
+            <span className="sm:hidden">{t("editor.save")}</span>
           </button>
-        )}
+          {canPublish && (
+            <button
+              type="submit"
+              name="intent"
+              value="publish"
+              className="shrink-0 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {t("editor.publish")} ↗
+            </button>
+          )}
+        </div>
       </div>
 
       {/* ------------------------------------------------------------------ */}

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -39,6 +39,8 @@ interface SidebarProps {
   currentSlug?: string
   userRole?: string
   isOpen?: boolean
+  isMobile?: boolean
+  onClose?: () => void
   onStarredClick?: () => void
 }
 
@@ -47,6 +49,8 @@ export default function Sidebar({
   currentSlug,
   userRole,
   isOpen = true,
+  isMobile = false,
+  onClose,
   onStarredClick,
 }: SidebarProps) {
   const { t } = useTranslation()
@@ -63,7 +67,8 @@ export default function Sidebar({
   const startWidth = useRef(0)
   const [isResizing, setIsResizing] = useState(false)
 
-  const isCollapsed = width < COLLAPSE_THRESHOLD
+  // On mobile: always expanded, never collapsed
+  const isCollapsed = isMobile ? false : width < COLLAPSE_THRESHOLD
   const displayWidth = isOpen ? width : 0
   const transition = isResizing ? "none" : "width 200ms ease"
 
@@ -111,6 +116,98 @@ export default function Sidebar({
     }
   }, [onMouseMove, onMouseUp])
 
+  const sidebarContent = (
+    <div className="flex h-full flex-col">
+      {/* Nav items */}
+      <nav aria-label="Main navigation" className="space-y-0.5 px-2 pb-1 pt-3">
+        <NavItem
+          to="/"
+          icon={<Home size={16} />}
+          label={t("nav.home")}
+          isCollapsed={isCollapsed}
+          isActive={location.pathname === "/"}
+        />
+        <NavItem
+          to="/recent"
+          icon={<Clock size={16} />}
+          label={t("nav.recent")}
+          isCollapsed={isCollapsed}
+          isActive={location.pathname === "/recent"}
+        />
+        {onStarredClick ? (
+          <button
+            type="button"
+            title={isCollapsed ? t("nav.starred") : undefined}
+            onClick={onStarredClick}
+            className="flex min-h-8 w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-100"
+          >
+            <span className="flex-shrink-0">
+              <Star size={16} />
+            </span>
+            {!isCollapsed && <span className="truncate">{t("nav.starred")}</span>}
+          </button>
+        ) : (
+          <NavItem
+            to="/starred"
+            icon={<Star size={16} />}
+            label={t("nav.starred")}
+            isCollapsed={isCollapsed}
+            isActive={location.pathname === "/starred"}
+          />
+        )}
+        {userRole === "admin" && (
+          <NavItem
+            to="/admin"
+            icon={<Settings size={16} />}
+            label={t("nav.admin")}
+            isCollapsed={isCollapsed}
+            isActive={location.pathname.startsWith("/admin")}
+          />
+        )}
+      </nav>
+
+      {/* Divider */}
+      <div className="mx-2 my-1 border-t border-gray-100" />
+
+      {/* Page tree */}
+      <div className="min-h-0 flex-1">
+        <PageTree
+          pages={pages}
+          currentSlug={currentSlug}
+          isCollapsed={isCollapsed}
+          canReorder={
+            !isMobile && !isCollapsed && ["member", "lead", "admin"].includes(userRole ?? "")
+          }
+        />
+      </div>
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        {/* Backdrop */}
+        {isOpen && (
+          <div
+            className="fixed inset-0 top-14 z-30 bg-black/40"
+            onClick={onClose}
+            onKeyDown={(e) => e.key === "Escape" && onClose?.()}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Drawer */}
+        <aside
+          className={`fixed bottom-0 left-0 top-14 z-40 w-64 overflow-hidden border-r border-gray-200 bg-white transition-transform duration-200 ease-in-out ${
+            isOpen ? "translate-x-0" : "-translate-x-full"
+          }`}
+        >
+          {sidebarContent}
+        </aside>
+      </>
+    )
+  }
+
   return (
     <>
       {/* Sidebar */}
@@ -118,74 +215,13 @@ export default function Sidebar({
         style={{ width: displayWidth, transition }}
         className="fixed bottom-0 left-0 top-14 overflow-hidden border-r border-gray-200 bg-white"
       >
-        <div className="flex h-full flex-col">
-          {/* Nav items */}
-          <nav aria-label="Main navigation" className="px-2 pt-3 pb-1 space-y-0.5">
-            <NavItem
-              to="/"
-              icon={<Home size={16} />}
-              label={t("nav.home")}
-              isCollapsed={isCollapsed}
-              isActive={location.pathname === "/"}
-            />
-            <NavItem
-              to="/recent"
-              icon={<Clock size={16} />}
-              label={t("nav.recent")}
-              isCollapsed={isCollapsed}
-              isActive={location.pathname === "/recent"}
-            />
-            {onStarredClick ? (
-              <button
-                type="button"
-                title={isCollapsed ? t("nav.starred") : undefined}
-                onClick={onStarredClick}
-                className="flex min-h-8 w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                <span className="flex-shrink-0">
-                  <Star size={16} />
-                </span>
-                {!isCollapsed && <span className="truncate">{t("nav.starred")}</span>}
-              </button>
-            ) : (
-              <NavItem
-                to="/starred"
-                icon={<Star size={16} />}
-                label={t("nav.starred")}
-                isCollapsed={isCollapsed}
-                isActive={location.pathname === "/starred"}
-              />
-            )}
-            {userRole === "admin" && (
-              <NavItem
-                to="/admin"
-                icon={<Settings size={16} />}
-                label={t("nav.admin")}
-                isCollapsed={isCollapsed}
-                isActive={location.pathname.startsWith("/admin")}
-              />
-            )}
-          </nav>
-
-          {/* Divider */}
-          <div className="mx-2 my-1 border-t border-gray-100" />
-
-          {/* Page tree */}
-          <div className="min-h-0 flex-1">
-            <PageTree
-              pages={pages}
-              currentSlug={currentSlug}
-              isCollapsed={isCollapsed}
-              canReorder={!isCollapsed && ["member", "lead", "admin"].includes(userRole ?? "")}
-            />
-          </div>
-        </div>
+        {sidebarContent}
 
         {/* Drag handle */}
         {isOpen && (
           <div
             onMouseDown={onDragHandleMouseDown}
-            className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-blue-200/50 active:bg-blue-300/50"
+            className="absolute bottom-0 right-0 top-0 w-1 cursor-col-resize hover:bg-blue-200/50 active:bg-blue-300/50"
             aria-hidden="true"
           />
         )}

--- a/web/app/components/Toast.tsx
+++ b/web/app/components/Toast.tsx
@@ -12,7 +12,7 @@ export default function Toast({ message, onDismiss }: ToastProps) {
   }, [onDismiss])
 
   return (
-    <div className="fixed right-4 top-4 z-50 flex items-center gap-3 rounded-lg bg-green-500 px-4 py-3 text-white shadow-lg">
+    <div className="fixed right-4 top-16 z-50 flex max-w-[calc(100vw-2rem)] items-center gap-3 rounded-lg bg-green-500 px-4 py-3 text-white shadow-lg">
       <span className="text-sm font-medium">{message}</span>
       <button
         type="button"

--- a/web/app/hooks/useMediaQuery.ts
+++ b/web/app/hooks/useMediaQuery.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react"
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia(query)
+    setMatches(mql.matches)
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches)
+    mql.addEventListener("change", handler)
+    return () => mql.removeEventListener("change", handler)
+  }, [query])
+
+  return matches
+}

--- a/web/app/locales/en/common.json
+++ b/web/app/locales/en/common.json
@@ -41,7 +41,8 @@
     "this_page": "This page",
     "star_add": "Add",
     "star_remove": "Remove",
-    "unstar": "Unstar"
+    "unstar": "Unstar",
+    "contents": "Contents"
   },
   "home": {
     "recently_updated": "Recently Updated",
@@ -327,7 +328,8 @@
     "saved_at": "Saved {{time}}",
     "autosave_failed": "Auto-save failed",
     "title_ja": "Title (Japanese)",
-    "title_en": "Title (English)"
+    "title_en": "Title (English)",
+    "save": "Save"
   },
   "privacy": {
     "title": "Privacy Policy",

--- a/web/app/locales/ja/common.json
+++ b/web/app/locales/ja/common.json
@@ -41,7 +41,8 @@
     "this_page": "このページ",
     "star_add": "追加",
     "star_remove": "削除",
-    "unstar": "お気に入りを外す"
+    "unstar": "お気に入りを外す",
+    "contents": "目次"
   },
   "home": {
     "recently_updated": "最近の更新",
@@ -327,7 +328,8 @@
     "saved_at": "{{time}} に保存",
     "autosave_failed": "自動保存に失敗しました",
     "title_ja": "タイトル（日本語）",
-    "title_en": "タイトル（英語）"
+    "title_en": "タイトル（英語）",
+    "save": "保存"
   },
   "privacy": {
     "title": "プライバシーポリシー",

--- a/web/app/routes/_app.tsx
+++ b/web/app/routes/_app.tsx
@@ -1,13 +1,14 @@
 import { and, eq, isNull, sql } from "drizzle-orm"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Outlet, useLoaderData, useParams } from "react-router"
+import { Outlet, useLoaderData, useLocation, useParams } from "react-router"
 import type { LoaderFunctionArgs } from "react-router"
 import Footer from "~/components/Footer"
 import Navbar from "~/components/Navbar"
 import Sidebar from "~/components/Sidebar"
 import StarredDialog from "~/components/StarredDialog"
 import * as schema from "~/db/schema"
+import { useMediaQuery } from "~/hooks/useMediaQuery"
 import { requireRole } from "~/lib/auth-utils.server"
 import { getDb } from "~/lib/db.server"
 import { buildTree } from "~/lib/page-tree"
@@ -56,32 +57,49 @@ export default function AppLayout() {
   const { user, pageTree, unreadNotificationCount } = useLoaderData<typeof loader>()
   const { slug } = useParams()
   const { i18n } = useTranslation()
+  const location = useLocation()
 
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const isMobile = useMediaQuery("(max-width: 767px)")
+
+  const [desktopOpen, setDesktopOpen] = useState(true)
+  const [mobileOpen, setMobileOpen] = useState(false)
   const [starredDialogOpen, setStarredDialogOpen] = useState(false)
 
   const lang: "ja" | "en" = i18n.language === "en" ? "en" : "ja"
 
+  // Restore desktop sidebar state from localStorage
   useEffect(() => {
     try {
       const stored = localStorage.getItem("gdgoc-sidebar-open")
-      if (stored !== null) setSidebarOpen(stored === "true")
+      if (stored !== null) setDesktopOpen(stored === "true")
     } catch {
       // ignore – localStorage unavailable
     }
   }, [])
 
+  // Close mobile drawer on route change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger on pathname change
+  useEffect(() => {
+    setMobileOpen(false)
+  }, [location.pathname])
+
   function toggleSidebar() {
-    setSidebarOpen((v) => {
-      const next = !v
-      try {
-        localStorage.setItem("gdgoc-sidebar-open", String(next))
-      } catch {
-        // ignore
-      }
-      return next
-    })
+    if (isMobile) {
+      setMobileOpen((v) => !v)
+    } else {
+      setDesktopOpen((v) => {
+        const next = !v
+        try {
+          localStorage.setItem("gdgoc-sidebar-open", String(next))
+        } catch {
+          // ignore
+        }
+        return next
+      })
+    }
   }
+
+  const sidebarOpen = isMobile ? mobileOpen : desktopOpen
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -98,6 +116,8 @@ export default function AppLayout() {
           currentSlug={slug}
           userRole={user.role}
           isOpen={sidebarOpen}
+          isMobile={isMobile}
+          onClose={() => setMobileOpen(false)}
           onStarredClick={() => setStarredDialogOpen(true)}
         />
 

--- a/web/app/routes/_index.tsx
+++ b/web/app/routes/_index.tsx
@@ -96,7 +96,7 @@ export default function Index() {
   const { t } = useTranslation()
 
   return (
-    <div className="max-w-5xl px-8 py-8">
+    <div className="max-w-5xl px-4 py-6 md:px-8 md:py-8">
       {/* Recently Updated */}
       <section className="mb-10">
         <h2 className="mb-4 text-lg font-semibold text-gray-900">{t("home.recently_updated")}</h2>
@@ -104,7 +104,7 @@ export default function Index() {
         {recentPages.length === 0 ? (
           <p className="text-sm text-gray-400">{t("home.no_pages_yet")}</p>
         ) : (
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {recentPages.map((page) => (
               <Link
                 key={page.id}

--- a/web/app/routes/search.tsx
+++ b/web/app/routes/search.tsx
@@ -135,7 +135,7 @@ export default function SearchPage() {
   const isJa = i18n.language === "ja"
 
   return (
-    <div className="max-w-3xl px-8 py-8">
+    <div className="max-w-3xl px-4 py-6 md:px-8 md:py-8">
       <h1 className="mb-1 text-lg font-semibold text-gray-900">{t("search.title")}</h1>
 
       {!q ? (

--- a/web/app/routes/wiki.$slug.tsx
+++ b/web/app/routes/wiki.$slug.tsx
@@ -1,11 +1,11 @@
 import { and, eq } from "drizzle-orm"
 import { MdPreview } from "md-editor-rt"
 import "md-editor-rt/lib/preview.css"
-import { Pencil, Share2, Star } from "lucide-react"
+import { List, Pencil, Share2, Star, X } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router"
-import { Link, useFetcher, useLoaderData } from "react-router"
+import { Link, useFetcher, useLoaderData, useLocation } from "react-router"
 import type { TocItem } from "~/components/WikiRightSidebar"
 import WikiRightSidebar from "~/components/WikiRightSidebar"
 import * as schema from "~/db/schema"
@@ -223,6 +223,7 @@ export default function WikiPage() {
   const { page, tags, author, editor, lang, userRole, visibility, canChangeVisibility, isStarred } =
     useLoaderData<typeof loader>()
   const { t } = useTranslation()
+  const location = useLocation()
   const contentLangFetcher = useFetcher()
   const submitRef = contentLangFetcher.submit
 
@@ -264,11 +265,18 @@ export default function WikiPage() {
   const favFetcher = useFetcher<{ ok: boolean; starred: boolean }>()
   const [currentStarred, setCurrentStarred] = useState(isStarred)
   const [copied, setCopied] = useState(false)
+  const [mobileContentsOpen, setMobileContentsOpen] = useState(false)
 
   // Sync with loader when navigating to a different page
   useEffect(() => {
     setCurrentStarred(isStarred)
   }, [isStarred])
+
+  // Close mobile contents sheet on route change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger on pathname change
+  useEffect(() => {
+    setMobileContentsOpen(false)
+  }, [location.pathname])
 
   // Optimistic star state for the action bar toggle
   const optimisticStarred = favFetcher.state !== "idle" ? !currentStarred : currentStarred
@@ -284,13 +292,16 @@ export default function WikiPage() {
     })
   }
 
+  const jaUrl = `${location.pathname}?lang=ja`
+  const enUrl = `${location.pathname}?lang=en`
+
   const btnBase =
     "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
 
   return (
     <div>
       {/* Action bar */}
-      <div className="flex items-center justify-end gap-1 border-b border-gray-100 px-10 py-2">
+      <div className="flex items-center justify-end gap-1 border-b border-gray-100 px-4 py-2 md:px-10">
         {canEdit && (
           <Link to={`/wiki/${page.slug}/edit`} className={btnBase}>
             <Pencil size={14} />
@@ -316,8 +327,20 @@ export default function WikiPage() {
       </div>
 
       <div className="flex gap-0">
-        <article className="max-w-3xl flex-1 min-w-0 px-10 py-8">
+        <article className="max-w-3xl min-w-0 flex-1 px-4 py-6 md:px-10 md:py-8">
           <h1 className="mb-4 text-3xl font-bold text-gray-900">{title}</h1>
+
+          {/* Mobile "Contents" button */}
+          {tocItems.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setMobileContentsOpen(true)}
+              className="mb-4 flex items-center gap-1.5 rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-600 md:hidden"
+            >
+              <List size={14} />
+              {t("wiki.contents")}
+            </button>
+          )}
 
           {tags.length > 0 && (
             <div className="mb-6 flex flex-wrap gap-2">
@@ -352,19 +375,131 @@ export default function WikiPage() {
           )}
         </article>
 
-        <WikiRightSidebar
-          tocItems={tocItems}
-          author={author}
-          editor={editor}
-          updatedAt={page.updatedAt}
-          tags={tags}
-          lang={lang}
-          translationStatusJa={page.translationStatusJa}
-          translationStatusEn={page.translationStatusEn}
-          slug={page.slug}
-          visibility={visibility}
-          canChangeVisibility={canChangeVisibility}
+        {/* Right sidebar — hidden on mobile */}
+        <div className="hidden md:block">
+          <WikiRightSidebar
+            tocItems={tocItems}
+            author={author}
+            editor={editor}
+            updatedAt={page.updatedAt}
+            tags={tags}
+            lang={lang}
+            translationStatusJa={page.translationStatusJa}
+            translationStatusEn={page.translationStatusEn}
+            slug={page.slug}
+            visibility={visibility}
+            canChangeVisibility={canChangeVisibility}
+          />
+        </div>
+      </div>
+
+      {/* Mobile contents bottom sheet */}
+      {mobileContentsOpen && (
+        <div
+          className="fixed inset-0 top-14 z-40 bg-black/40 md:hidden"
+          onClick={() => setMobileContentsOpen(false)}
+          onKeyDown={(e) => e.key === "Escape" && setMobileContentsOpen(false)}
+          aria-hidden="true"
         />
+      )}
+      <div
+        className={`fixed bottom-0 left-0 right-0 z-50 max-h-[70vh] overflow-y-auto rounded-t-xl bg-white shadow-xl transition-transform duration-200 ease-in-out md:hidden ${
+          mobileContentsOpen ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
+        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+          <p className="font-semibold text-gray-900">{t("wiki.contents")}</p>
+          <button
+            type="button"
+            onClick={() => setMobileContentsOpen(false)}
+            className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-4 py-3 space-y-5">
+          {/* Language toggle */}
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {t("wiki.read_in")}
+            </p>
+            <div className="flex gap-1">
+              {(["ja", "en"] as const).map((l) => {
+                const status = l === "ja" ? page.translationStatusJa : page.translationStatusEn
+                const isPending = status === "missing"
+                const isActive = lang === l
+                return (
+                  <Link
+                    key={l}
+                    to={l === "ja" ? jaUrl : enUrl}
+                    onClick={() => setMobileContentsOpen(false)}
+                    aria-disabled={isPending}
+                    title={isPending ? t("wiki.translation_pending") : undefined}
+                    className={[
+                      "flex-1 rounded px-2 py-1 text-center text-sm font-medium transition-colors",
+                      isActive
+                        ? "bg-blue-500 text-white"
+                        : isPending
+                          ? "pointer-events-none text-gray-300"
+                          : "text-gray-600 hover:bg-gray-100",
+                    ].join(" ")}
+                  >
+                    {l === "ja" ? "JA" : "EN"}
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* TOC */}
+          {tocItems.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                {t("wiki.on_this_page")}
+              </p>
+              <nav aria-label="Table of contents">
+                <ul className="space-y-1">
+                  {tocItems.map((item) => (
+                    <li
+                      key={item.id}
+                      style={{ paddingLeft: item.level === 3 ? "0.75rem" : undefined }}
+                    >
+                      <a
+                        href={`#${item.id}`}
+                        onClick={() => setMobileContentsOpen(false)}
+                        className="block truncate py-1 text-sm text-gray-600 hover:text-gray-900"
+                      >
+                        {item.text}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            </div>
+          )}
+
+          {/* Tags */}
+          {tags.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                {t("wiki.tags")}
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {tags.map((tag) => (
+                  <span
+                    key={tag.tagSlug}
+                    className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium text-white"
+                    style={{ backgroundColor: tag.color }}
+                  >
+                    {lang === "en" ? tag.labelEn : tag.labelJa}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- **`useMediaQuery` hook** — SSR-safe (initializes to `false`), subscribes via `useEffect`
- **Sidebar** — mobile drawer mode: fixed overlay slides in from left, backdrop dims content, closes on route change or backdrop tap; no drag-and-drop on mobile
- **Navbar** — tighter gap/padding on mobile; square logo (`logo_square.png`) on mobile, full logo on sm+; "New page" button hidden on mobile
- **NotificationBell** — dropdown width capped to `100vw - 1.5rem` to prevent left-edge overflow
- **Toast** — moved to `top-16` to clear the fixed navbar; `max-w-[calc(100vw-2rem)]` overflow guard
- **Home page** — grid goes 1 col → 2 col (sm) → 3 col (lg); responsive padding
- **Search page** — responsive padding
- **PageEditor** — header switches to 2-column grid on mobile: col 1 = back + title, col 2 = lang switcher + Save + Publish; autosave status and Draft badge hidden on mobile
- **wiki/\$slug** — right sidebar hidden on mobile; "Contents" button (md:hidden) opens bottom sheet with TOC, language toggle, and tags
- **i18n** — added `wiki.contents` and `editor.save` keys to EN and JA locale files

## Test plan
- [ ] Resize to 375 px: hamburger opens sidebar drawer; backdrop tap closes it; navigating closes it automatically
- [ ] Square logo visible on mobile, full logo on sm+
- [ ] Notification dropdown doesn't overflow left edge on mobile
- [ ] Toast appears below navbar (not behind it)
- [ ] Home page: 1 col on mobile, 2 on sm, 3 on lg
- [ ] Search page padding looks correct on mobile
- [ ] Editor header: 2-column layout on mobile, single row on sm+
- [ ] Wiki page on mobile: right sidebar hidden; "Contents" button present; tapping opens bottom sheet with TOC + lang toggle + tags; tapping a heading closes sheet
- [ ] `pnpm check` and `pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced mobile responsiveness with adaptive layouts for navigation, sidebar, and article contents.
  * Introduced mobile drawer for sidebar navigation and bottom sheet for accessing wiki article contents and language selection on smaller screens.

* **Style**
  * Improved spacing and padding adjustments throughout the app for responsive design.
  * Updated header layout with optimized logo display across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->