### PR TITLE
fix(cd): use pnpm run deploy instead of pnpm deploy in discord bot wo…

### DIFF
--- a/.github/workflows/cd-discord-bot.yml
+++ b/.github/workflows/cd-discord-bot.yml
@@ -34,7 +34,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: discord-bot/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
-      - run: pnpm deploy
+      - run: pnpm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
…rkflow

pnpm deploy is a built-in workspace command, not a script runner. Using pnpm run deploy correctly executes the wrangler deploy script.

## Summary

<!-- Describe what this PR does and why. -->

## Changes

-

## Test Plan

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if UI-facing)
- [ ] Manual testing completed

## Checklist

- [ ] `npm run check` passes (Biome lint + format)
- [ ] `npm run typecheck` passes
- [ ] `npm run test` passes
- [ ] Terraform: `terraform fmt` and `terraform validate` pass (if infra changed)
- [ ] No secrets or sensitive data committed
- [ ] Documentation / specs updated if needed

## Related Issues

<!-- Closes #123 -->
