### PR TITLE
fix(email): enable real email sending in production

### DIFF
--- a/web/.dev.vars.example
+++ b/web/.dev.vars.example
@@ -12,3 +12,5 @@ GOOGLE_CLIENT_SECRET=
 
 # Optional — only needed for AI ingestion/translation features
 GEMINI_API_KEY=
+
+ENVIRONMENT=development

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -22,7 +22,7 @@ pattern = "wiki.gdgoc-osaka.jp/*"
 zone_name = "gdgoc-osaka.jp"
 
 [vars]
-ENVIRONMENT = "development"
+ENVIRONMENT = "production"
 
 # ---------------------------------------------------------------------------
 # Cloudflare D1 — managed SQLite database


### PR DESCRIPTION
## Summary
- `wrangler.toml`: change `ENVIRONMENT` from `"development"` to `"production"` so the deployed worker passes the DEV MODE guard in `email.server.ts`
- `.dev.vars` / `.dev.vars.example`: add `ENVIRONMENT=development` so local dev (`pnpm dev`) still logs instead of sending real emails

## Root cause
`email.server.ts` guards real sending behind `env.ENVIRONMENT !== "production"`. `wrangler.toml` had `ENVIRONMENT = "development"` with no production override, so every deployed worker saw `"development"` and only logged.

## Test plan
- [ ] Local dev (`pnpm dev`): trigger an invitation email → should still log "[email.server] DEV MODE"
- [ ] After deploying to production: trigger chapter creation → invitation email should arrive at the lead's address

🤖 Generated with [Claude Code](https://claude.ai/claude-code)