### PR TITLE
fix(ingestion): guard against empty PDF and catch Gemini upload errors

### DIFF
--- a/web/app/lib/ingestion-pipeline/run-preprocess.ts
+++ b/web/app/lib/ingestion-pipeline/run-preprocess.ts
@@ -456,17 +456,30 @@ export async function step26FetchSelectedUrls(
       console.log("[ingestion-pipeline] step 2.6: trying PDF for", url)
       const pdfResult = await fetchUrlAsPdf(env.BROWSER as BrowserWorker, url)
       if (pdfResult.error === undefined) {
-        const hostname = new URL(url).hostname
-        const geminiUri = await uploadFileToGemini(
-          pdfResult.buffer,
-          "application/pdf",
-          hostname,
-          env.GEMINI_API_KEY,
-        )
-        fileUris.push({ uri: geminiUri, mimeType: "application/pdf" })
-        sources.push({ url, title: pdfResult.title || url })
-        uploadedPdf = true
-        console.log("[ingestion-pipeline] URL PDF uploaded:", url, "→", geminiUri)
+        const pdfByteLength = pdfResult.buffer.byteLength
+        if (pdfByteLength === 0) {
+          console.warn("[ingestion-pipeline] URL PDF is empty, falling back to Jina:", url)
+        } else {
+          const hostname = new URL(url).hostname
+          try {
+            const geminiUri = await uploadFileToGemini(
+              pdfResult.buffer,
+              "application/pdf",
+              hostname,
+              env.GEMINI_API_KEY,
+            )
+            fileUris.push({ uri: geminiUri, mimeType: "application/pdf" })
+            sources.push({ url, title: pdfResult.title || url })
+            uploadedPdf = true
+            console.log("[ingestion-pipeline] URL PDF uploaded:", url, "→", geminiUri)
+          } catch (uploadErr) {
+            console.warn(
+              "[ingestion-pipeline] URL PDF Gemini upload failed, falling back to Jina:",
+              url,
+              uploadErr,
+            )
+          }
+        }
       } else {
         console.warn(
           "[ingestion-pipeline] URL PDF failed, falling back to Jina:",


### PR DESCRIPTION
## Summary
- After the puppeteer upgrade, URL PDF capture started succeeding but Gemini responded `400 No file found in request` — because `page.pdf()` can return a 0-byte buffer for pages that fail to render as PDF
- The upload error propagated uncaught, killing the entire pipeline session instead of falling back gracefully
- Fix: check `pdfResult.buffer.byteLength === 0` before attempting the upload, and wrap `uploadFileToGemini` in a try/catch so any failure falls through to the Jina text fallback

## Test plan
- [ ] Submit a URL in the ingest form on production → pipeline should complete (not error-terminate)
- [ ] Check Worker logs: on PDF upload failure, should see `URL PDF Gemini upload failed, falling back to Jina:` instead of session error
- [ ] CI: all passing ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF document ingestion reliability with enhanced handling for empty files and upload failures, automatically falling back to alternative processing methods to ensure successful document processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->