### PR TITLE
fix(ingestion): validate PDF signature before uploading to Gemini

### DIFF
--- a/web/app/lib/url-extract.ts
+++ b/web/app/lib/url-extract.ts
@@ -93,10 +93,25 @@ export async function fetchUrlAsPdf(
     await page.goto(url, { waitUntil: "networkidle2", timeout: timeoutMs })
     const title = await page.title()
     const pdfBuffer = await page.pdf({ format: "A4", printBackground: true })
+    // Defensive copy: pdfBuffer may be a Node.js Buffer with a shared backing
+    // ArrayBuffer, so always copy to get an isolated, correctly-sized ArrayBuffer.
     const arrayBuffer = pdfBuffer.buffer.slice(
       pdfBuffer.byteOffset,
       pdfBuffer.byteOffset + pdfBuffer.byteLength,
     ) as ArrayBuffer
+    // Validate the PDF signature (%PDF-). page.pdf() can return non-PDF bytes
+    // (e.g. garbled binary from the CDP transport) that would cause Gemini to
+    // reject the upload with "400 No file found in request".
+    const header = new Uint8Array(arrayBuffer, 0, Math.min(4, arrayBuffer.byteLength))
+    if (header[0] !== 0x25 || header[1] !== 0x50 || header[2] !== 0x44 || header[3] !== 0x46) {
+      return {
+        error: `page.pdf() returned non-PDF data (${arrayBuffer.byteLength} bytes, first bytes: ${Array.from(
+          header,
+        )
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join(" ")})`,
+      }
+    }
     return { buffer: arrayBuffer, title }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary
- `page.pdf()` in `@cloudflare/puppeteer` can return a non-empty buffer that doesn't contain valid PDF bytes (e.g. garbled data from the CDP transport)
- Gemini rejects such uploads with `400 No file found in request.`
- The root cause shows in logs: `step 2.6: fetching via Jina` appears before `URL PDF Gemini upload failed` — Cloudflare log ordering is non-deterministic, but execution is sequential and the fallback IS working
- Fix: after `page.pdf()` returns, check the first 4 bytes for the `%PDF-` signature (`25 50 44 46`). If they don't match, return a descriptive error (byte count + hex dump of first bytes) so the caller falls through to Jina and we get enough information in logs to diagnose the CDP issue

## Test plan
- [ ] Check Worker logs after deploying: on invalid PDF, should see `page.pdf() returned non-PDF data (N bytes, first bytes: xx xx xx xx)` instead of `400 No file found in request`
- [ ] Verify that Jina fallback still runs and content is included in the generated page
- [ ] CI: all passing ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)